### PR TITLE
Separate binstreams based on viewId

### DIFF
--- a/cfg/common/ctc-common.cfg
+++ b/cfg/common/ctc-common.cfg
@@ -74,5 +74,5 @@ enhancedOccupancyMapCode:                 0
 
 ##
 # profile reconstruction idc parameters
-profileReconstructionIdc:                 1
+profileReconstructionIdc:                 0
 

--- a/cfg/rate/ctc-r-1.cfg
+++ b/cfg/rate/ctc-r-1.cfg
@@ -1,0 +1,12 @@
+##
+# Rate parameters for all sequences and test categories for use with
+# TMC2 according to N17229 common test conditions.
+
+geometryQP:          40
+attributeQP:         52
+
+##
+# occupancy map parameters
+
+occupancyPrecision:  2
+

--- a/cfg/rate/ctc-r0.cfg
+++ b/cfg/rate/ctc-r0.cfg
@@ -1,0 +1,12 @@
+##
+# Rate parameters for all sequences and test categories for use with
+# TMC2 according to N17229 common test conditions.
+
+geometryQP:          36
+attributeQP:         47
+
+##
+# occupancy map parameters
+
+occupancyPrecision:  2
+

--- a/cfg/sequence/longdress_vox10.cfg
+++ b/cfg/sequence/longdress_vox10.cfg
@@ -2,7 +2,7 @@
 # Source perameters for the given sequence
 # -- NB: the following paths will likely need to be overridden by the user
 
-uncompressedDataPath:              8i/8iVFBv2/longdress/Ply/longdress_vox10_%i.ply
+uncompressedDataPath:              longdress/Ply/longdress_vox10_%i.ply
 geometry3dCoordinatesBitdepth:     10
 geometryNominal2dBitdepth:         8
 frameCount:                        300

--- a/source/lib/PccLibEncoder/include/PCCEncoder.h
+++ b/source/lib/PccLibEncoder/include/PCCEncoder.h
@@ -117,7 +117,7 @@ class PCCEncoder : public PCCCodec {
   ~PCCEncoder();
   void setParameters( const PCCEncoderParameters& params );
 
-  int encode( const PCCGroupOfFrames& sources, PCCContext& context, PCCGroupOfFrames& reconstructs );
+  int encode( const PCCGroupOfFrames& sources, PCCContext& context, PCCGroupOfFrames& reconstructs, size_t* viewId = nullptr );
 
   void setPostProcessingSeiParameters( GeneratePointCloudParameters& params, PCCContext& context );
   void setGeneratePointCloudParameters( GeneratePointCloudParameters& gpcParams, PCCContext& context );
@@ -175,12 +175,13 @@ class PCCEncoder : public PCCCodec {
   void   replaceFrameContext( PCCContext& context );
 
   //**patch segmentation**//
-  bool generateSegments( const PCCGroupOfFrames& sources, PCCContext& context );
+  bool generateSegments( const PCCGroupOfFrames& sources, PCCContext& context, size_t* viewId = nullptr );
   bool generateSegments( const PCCPointSet3&                 source,
                          PCCAtlasFrameContext&               frameContext,
                          const PCCPatchSegmenter3Parameters& segmenterParams,
                          size_t                              frameIndex,
-                         float&                              distanceSrcRec );
+                         float&                              distanceSrcRec,
+                         size_t*                             viewId = nullptr );
   bool placeSegments( const PCCGroupOfFrames& sources, PCCContext& context );
 
   //**video/image reneration and resizing**//

--- a/source/lib/PccLibEncoder/source/PCCEncoder.cpp
+++ b/source/lib/PccLibEncoder/source/PCCEncoder.cpp
@@ -68,7 +68,7 @@ PCCEncoder::~PCCEncoder() = default;
 
 void PCCEncoder::setParameters( const PCCEncoderParameters& params ) { params_ = params; }
 
-int PCCEncoder::encode( const PCCGroupOfFrames& sources, PCCContext& context, PCCGroupOfFrames& reconstructs ) {
+int PCCEncoder::encode( const PCCGroupOfFrames& sources, PCCContext& context, PCCGroupOfFrames& reconstructs, size_t* viewId ) {
   size_t pointLocalReconstructionOriginal   = static_cast<size_t>( params_.pointLocalReconstruction_ );
   size_t layerCountMinus1Original           = params_.mapCountMinus1_;
   size_t singleMapPixelInterleavingOriginal = static_cast<size_t>( params_.singleMapPixelInterleaving_ );
@@ -100,8 +100,8 @@ int PCCEncoder::encode( const PCCGroupOfFrames& sources, PCCContext& context, PC
     frameContext.setLog2PatchQuantizerSizeY( params_.log2QuantizerSizeY_ );
   }
 
-  // Segmentation
-  generateSegments( sources, context );
+  // Patches are generated here
+  generateSegments( sources, context, viewId );
 
   // Init context and tiles
   params_.initializeContext( context );
@@ -122,6 +122,9 @@ int PCCEncoder::encode( const PCCGroupOfFrames& sources, PCCContext& context, PC
   auto&             sps        = context.getVps();
   std::stringstream path;
   path << removeFileExtension( params_.compressedStreamPath_ ) << "_GOF" << sps.getV3CParameterSetId() << "_";
+  if (viewId != nullptr) {
+    path << *viewId << "_";
+  }
   sps.setFrameWidth( atlasIndex, static_cast<uint16_t>( frames[0].getAtlasFrameWidth() ) );
   sps.setFrameHeight( atlasIndex, static_cast<uint16_t>( frames[0].getAtlasFrameHeight() ) );
   for ( auto& asps : context.getAtlasSequenceParameterSetList() ) {
@@ -3656,7 +3659,8 @@ bool PCCEncoder::generateSegments( const PCCPointSet3&                 source,
                                    PCCAtlasFrameContext&               frameContext,
                                    const PCCPatchSegmenter3Parameters& segmenterParams,
                                    size_t                              frameIndex,
-                                   float&                              distanceSrcRec ) {
+                                   float&                              distanceSrcRec,
+                                   size_t*                             viewId ) {
   if ( source.getPointCount() == 0u ) { return true; }
   auto& frame = frameContext.getTitleFrameContext();
   if ( segmenterParams.additionalProjectionPlaneMode_ != 5 ) {
@@ -3674,6 +3678,7 @@ bool PCCEncoder::generateSegments( const PCCPointSet3&                 source,
         if (patch.getViewId() == *viewId) {
           filtered_patches.push_back(patch);
         }
+        std::cout << i << std::endl;
       }
       frame.getPatches() = filtered_patches;
     }
@@ -4653,7 +4658,7 @@ void PCCEncoder::generateRawPointsAttributeImage( PCCContext&        context,
   }
 }
 
-bool PCCEncoder::generateSegments( const PCCGroupOfFrames& sources, PCCContext& context ) {
+bool PCCEncoder::generateSegments( const PCCGroupOfFrames& sources, PCCContext& context, size_t* viewId ) {
   PCCPatchSegmenter3Parameters params;
   bool                         res            = true;
   auto&                        frames         = context.getFrames();
@@ -4718,7 +4723,7 @@ bool PCCEncoder::generateSegments( const PCCGroupOfFrames& sources, PCCContext& 
   for ( size_t i = 0; i < frames.size(); i++ ) {
 #endif
       float distanceSrcRec = 0;
-      if ( !generateSegments( sources[i], frames[i], params, i, distanceSrcRec ) ) {
+      if ( !generateSegments( sources[i], frames[i], params, i, distanceSrcRec, viewId ) ) {
         res = false;
 #if defined( ENABLE_TBB )
         tbb::task::self().cancel_group_execution();
@@ -4765,6 +4770,8 @@ bool PCCEncoder::placeSegments( const PCCGroupOfFrames& sources, PCCContext& con
           if ( params_.packingStrategy_ < 2 ) {
             packFlexible( tile, params_.packingStrategy_, tileWidth, tileHeight, params_.safeGuardDistance_,
                           params_.enablePointCloudPartitioning_ );
+            // packViewpoint( tile, params_.packingStrategy_, tileWidth, tileHeight, params_.safeGuardDistance_,
+            //               params_.enablePointCloudPartitioning_ );
           } else if ( params_.packingStrategy_ == 2 ) {
             packTetris( tile, tileWidth, tileHeight, params_.safeGuardDistance_ );
           }

--- a/source/lib/PccLibEncoder/source/PCCEncoder.cpp
+++ b/source/lib/PccLibEncoder/source/PCCEncoder.cpp
@@ -3666,6 +3666,17 @@ bool PCCEncoder::generateSegments( const PCCPointSet3&                 source,
     segmenter.setNbThread( params_.nbThread_ );
     segmenter.compute( source, frame.getFrameIndex(), segmenterParams, patches, frame.getSrcPointCloudByPatch(),
                        distanceSrcRec );
+    if (viewId != nullptr) {
+      std::vector<PCCPatch> filtered_patches;
+      // std::vector<PCCPointSet3> filtered_src_point_cloud; Do we need to update src point cloud? last time i check it has length 0 after segmenter.compute(...)
+      for (auto i = 0; i < patches.size(); i++) {
+        PCCPatch patch = patches[i];
+        if (patch.getViewId() == *viewId) {
+          filtered_patches.push_back(patch);
+        }
+      }
+      frame.getPatches() = filtered_patches;
+    }
   } else {
     segmentationPartiallyAddtinalProjectionPlane( source, frame, segmenterParams, frameIndex, distanceSrcRec );
   }


### PR DESCRIPTION
For encoding compatibility with https://github.com/benclmnt/tmc2-rs/ and best compression, set `minimumImageWidth` and `minimumImageHeight` to 640 in `ctc-common.cfg`